### PR TITLE
Refactor `vimhelp.html` (moved to #7)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
  {;; for GraalVM
   ;; https://dev.clojure.org/jira/browse/CLJ-1472
   org.clojure/clojure {:mvn/version "1.10.1"}
-  hiccup {:mvn/version "1.0.5"}
+  hiccup/hiccup {:mvn/version "2.0.0-alpha2"}
   org.clojure/tools.cli {:mvn/version "1.0.194"}}
 
  :aliases

--- a/src/vimhelp/html.clj
+++ b/src/vimhelp/html.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [hiccup.core :as hiccup]
+   [hiccup2.core :as hiccup]
    [hiccup.page :as page])
   (:import
    java.net.URLEncoder))
@@ -11,11 +11,19 @@
   [s]
   (URLEncoder/encode s "UTF-8"))
 
-(defn- replace-spaces
+(defn replace-spaces
   [s]
-  (-> s
-      (str/replace " " "&nbsp;")
-      (str/replace "\t" "&nbsp;&nbsp;&nbsp;&nbsp;")))
+  (->> s
+       (partition-by #(case % \space 0 \tab 0 1))
+       (map (fn [char-seq]
+              (if (#{\space \tab} (first char-seq))
+                (->> char-seq
+                     (map #(case %
+                             \space "&nbsp;"
+                             \tab "&nbsp;&nbsp;&nbsp;&nbsp;"))
+                     (apply str)
+                     hiccup/raw)
+                (apply str char-seq))))))
 
 (defn html-file-name
   [index path]
@@ -32,39 +40,39 @@
   (->> (if (= [""] elements) [" "] elements)
        (map #(if (vector? %)
                (render* % opts)
-               (-> % hiccup/h replace-spaces)))
+               (replace-spaces %)))
        (cons :p)
        vec))
 
 (defmethod render* :tag
   [[_ tag-name] _]
-  [:a.tag {:name (url-encode tag-name)} (hiccup/h tag-name)])
+  [:a.tag {:name (url-encode tag-name)} tag-name])
 
 (defmethod render* :ref
   [[_ ref-name] {:keys [tags]}]
   [:a.ref {:class (when-not (contains? tags ref-name) "missing-tag")
            :href (str (get tags ref-name) "#" (url-encode ref-name))}
-   (hiccup/h ref-name)])
+   ref-name])
 
 (defmethod render* :constant
   [[_ constant-name] _]
-  [:span.constant (hiccup/h constant-name)])
+  [:span.constant constant-name])
 
 (defmethod render* :header
   [[_ header-text] _]
-  [:span.header (hiccup/h header-text)])
+  [:span.header header-text])
 
 (defmethod render* :command
   [[_ command] _]
-  [:code.command (hiccup/h command)])
+  [:code.command command])
 
 (defmethod render* :example
   [[_ example] _]
-  [:pre.example [:code (hiccup/h example)]])
+  [:pre.example [:code example]])
 
 (defmethod render* :url
   [[_ url] _]
-  [:a.url {:href url} (hiccup/h url)])
+  [:a.url {:href url} url])
 
 (defmethod render* :divider
   [[_ text] _]
@@ -75,7 +83,7 @@
   (let [[_ tag-name] tag]
     [:p.section-header
      [:a.section-link {:href (str "#" (url-encode tag-name))} "@"]
-     [:span.section-title (-> title hiccup/h replace-spaces)]
+     (into [:span.section-title] (replace-spaces title))
      (render* tag opts)]))
 
 (defn render

--- a/src/vimhelp/html.clj
+++ b/src/vimhelp/html.clj
@@ -2,8 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [hiccup2.core :as hiccup]
-   [hiccup.page :as page])
+   [hiccup2.core :as hiccup])
   (:import
    java.net.URLEncoder))
 
@@ -89,44 +88,46 @@
 (defn render
   ([parsed-data] (render parsed-data {}))
   ([parsed-data {:keys [title style copyright path blob index] :as opts}]
-   (page/html5
-    [:head
-     [:meta {:charset "UTF-8"}]
-     [:title title]
-     (for [href (:css opts)]
-       [:link {:rel "stylesheet" :href href}])
-     (when style
-       [:style {:type "text/css"} style])]
+   (str "<!DOCTYPE html>"
+        (hiccup/html
+         [:html
+          [:head
+           [:meta {:charset "UTF-8"}]
+           [:title title]
+           (for [href (:css opts)]
+             [:link {:rel "stylesheet" :href href}])
+           (when style
+             [:style {:type "text/css"} (hiccup/raw style)])]
 
-    [:body
-     [:header
-      [:h1.title title]
+          [:body
+           [:header
+            [:h1.title title]
 
-      (when (:show-navigation opts)
-        [:nav.files
-         [:input#current-file {:type "checkbox"}]
-         [:label {:for "current-file"} (.getName (io/file path))]
+            (when (:show-navigation opts)
+              [:nav.files
+               [:input#current-file {:type "checkbox"}]
+               [:label {:for "current-file"} (.getName (io/file path))]
 
-         [:ul
-          (for [path (sort #(cond
-                              (and index (str/ends-with? %1 index)) -1
-                              (and index (str/ends-with? %2 index)) 1
-                              :else (compare %1 %2))
-                           (:paths opts))]
-            [:li {:class (when (= path (:path opts)) "active")}
-             [:a {:href (html-file-name index path)}
-              (.getName (io/file path))]])]])
+               [:ul
+                (for [path (sort #(cond
+                                   (and index (str/ends-with? %1 index)) -1
+                                   (and index (str/ends-with? %2 index)) 1
+                                   :else (compare %1 %2))
+                                 (:paths opts))]
+                  [:li {:class (when (= path (:path opts)) "active")}
+                   [:a {:href (html-file-name index path)}
+                    (.getName (io/file path))]])]])
 
-      (when (and path blob)
-        [:p.edit-link
-         [:a {:href (str (str/replace blob #"/$" "") "/" (.getName (io/file path)))}
-          "Edit this page"]])]
+            (when (and path blob)
+              [:p.edit-link
+               [:a {:href (str (str/replace blob #"/$" "") "/" (.getName (io/file path)))}
+                "Edit this page"]])]
 
-     [:div {:class (:wrapper opts)}
-      (map #(render* % opts) parsed-data)]
+           [:div {:class (:wrapper opts)}
+            (map #(render* % opts) parsed-data)]
 
-     [:footer
-      (when copyright [:p.copyright copyright])
-      [:p.vimhelp
-       "Built by " [:a {:href "https://github.com/liquidz/clj-vimhelp"} "clj-vimhelp"]
-       " ver " (:version opts)]]])))
+           [:footer
+            (when copyright [:p.copyright copyright])
+            [:p.vimhelp
+             "Built by " [:a {:href "https://github.com/liquidz/clj-vimhelp"} "clj-vimhelp"]
+             " ver " (:version opts)]]]]))))

--- a/test/vimhelp/html_test.clj
+++ b/test/vimhelp/html_test.clj
@@ -1,23 +1,31 @@
 (ns vimhelp.html-test
   (:require
    [clojure.test :as t]
+   [hiccup2.core :as hiccup]
    [vimhelp.html :as sut]))
+
+(t/deftest replace-spaces-test
+  (t/is (= (list "hi" (hiccup/raw "&nbsp;&nbsp;") "there"
+                 (hiccup/raw "&nbsp;&nbsp;&nbsp;&nbsp;") "wow"
+                 (hiccup/raw "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;")
+                 "very" (hiccup/raw "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;") "cool")
+           (sut/replace-spaces "hi  there\twow\t\tvery \tcool"))))
 
 (t/deftest render-tag-test
   (t/are [in out] (= out (sut/render* [:tag in] {}))
     "foo",   [:a.tag {:name "foo"} "foo"]
-    "<foo>", [:a.tag {:name "%3Cfoo%3E"} "&lt;foo&gt;"]))
+    "<foo>", [:a.tag {:name "%3Cfoo%3E"} "<foo>"]))
 
 (t/deftest render-ref-test
   (t/are [in out] (= out (sut/render* [:ref in] {}))
     "foo",   [:a.ref {:class "missing-tag" :href "#foo"} "foo"]
-    "<foo>", [:a.ref {:class "missing-tag" :href "#%3Cfoo%3E"} "&lt;foo&gt;"])
+    "<foo>", [:a.ref {:class "missing-tag" :href "#%3Cfoo%3E"} "<foo>"])
 
   (let [tags {"foo" "index.html"
               "<foo>" "bar.html"}]
     (t/are [in out] (= out (sut/render* [:ref in] {:tags tags}))
       "foo",   [:a.ref {:class nil :href "index.html#foo"} "foo"]
-      "<foo>", [:a.ref {:class nil :href "bar.html#%3Cfoo%3E"} "&lt;foo&gt;"])))
+      "<foo>", [:a.ref {:class nil :href "bar.html#%3Cfoo%3E"} "<foo>"])))
 
 
 (t/deftest render-section-header-test
@@ -29,6 +37,6 @@
 
   (t/is (= [:p.section-header
             [:a.section-link {:href "#%3Cfoo%3E"} "@"]
-            [:span.section-title "&lt;title&gt;"]
-            [:a.tag {:name "%3Cfoo%3E"} "&lt;foo&gt;"]]
+            [:span.section-title "<title>"]
+            [:a.tag {:name "%3Cfoo%3E"} "<foo>"]]
            (sut/render* [:section-header "<title>" [:tag "<foo>"]] {}))))


### PR DESCRIPTION
These commits refactor `vimhelp.html` to use `hiccup2.core` which makes the hiccup-generating code much more reusable due to improved escaping semantics.

I won't be upset if this patch is unwanted, I just wanted to submit it upstream to see what author thinks.

Fixes #5 